### PR TITLE
Add new env var and script to exit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
+      EXIT_VALIDATOR: ""
+      KEYSTORES_VOLUNTARY_EXIT: ""
     restart: unless-stopped
     image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.0"
 volumes:

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -22,6 +22,23 @@ else
   fi
 fi
 
+
+if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]] && ! [ -z "$KEYSTORES_VOLUNTARY_EXIT" ]; then
+    echo "Check connectivity with the web3signer"
+    WEB3SIGNER_STATUS=$(curl -s  http://web3signer.web3signer-gnosis.dappnode:9000/healthcheck | jq '.status')
+    if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
+    echo "Proceeds to do the voluntary exit of the next keystores:"
+    echo "$KEYSTORES_VOLUNTARY_EXIT"
+    echo yes | exec /opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku-gnosis.dappnode:3500 \
+        --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
+        --validators-external-signer-url=$WEB3SIGNER_API
+    else
+      echo "The web3signer-gnosis is not running or the teku package has not access to the web3signer"
+      echo "The env var KEYSTORES_VOLUNTARY_EXIT: $KEYSTORES_VOLUNTARY_EXIT has a empty value"
+    fi
+fi
+
+
 # Teku must start with the current env due to JAVA_HOME var
 exec /opt/teku/bin/teku --log-destination=CONSOLE \
   validator-client \


### PR DESCRIPTION
This PR add the scripts and the env vars required to do an exit from the UI. It has been tested. The user must define in the EXIT_VALIDATOR: `I want to exit my validators` and define the validators pubkey in the var define as KEYSTORES_VOLUNTARY_EXIT