### PR TITLE
add seccomp to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "19005:19005/udp"
     restart: unless-stopped
     image: "beacon-chain.teku-gnosis.dnp.dappnode.eth:0.1.0"
+    security_opt:
+      - "seccomp:unconfined"
   validator:
     build:
       context: ./validator
@@ -36,5 +38,7 @@ services:
       KEYSTORES_VOLUNTARY_EXIT: ""
     restart: unless-stopped
     image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.0"
+    security_opt:
+      - "seccomp:unconfined"
 volumes:
   teku-gnosis-data: {}


### PR DESCRIPTION
Both services of this package (validator, beacon-chain) on restart loop, logs error:

`ERROR: JAVA_HOME is set to an invalid directory: /opt/java/openjdk`

`Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.`