### PR TITLE
Remove proposer fee recipient flag

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -35,5 +35,4 @@ exec /opt/teku/bin/teku \
     --metrics-host-allowlist "*" \
     --log-destination=CONSOLE \
     --logging=$LOG_TYPE \
-    --validators-proposer-default-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
     $EXTRA_OPTS


### PR DESCRIPTION
This fee recipient flag is causing:
`Teku failed to start: Invalid Default Fee Recipient: Bytes20 should be 20 bytes, but was 0 bytes.`