### PR TITLE
Add memory management java_opt to console

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update
 RUN mkdir -p /opt/teku/data
 RUN chown -R 1001:1001 /opt/teku/data
 
-ENV JAVA_OPTS="-Xmx5g"
 
 # API port: https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#rest-api-port
 EXPOSE $BEACON_API_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       FEE_RECIPIENT_ADDRESS: ""
       CHECKPOINT_SYNC_URL: ""
       EXTRA_OPTS: ""
+      JAVA_OPTS: "-Xmx5g"
     volumes:
       - "teku-gnosis-data:/opt/teku/data"
     ports:
@@ -36,6 +37,7 @@ services:
       FEE_RECIPIENT_ADDRESS: ""
       EXIT_VALIDATOR: ""
       KEYSTORES_VOLUNTARY_EXIT: ""
+      JAVA_OPTS: "-Xmx5g"
     restart: unless-stopped
     image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.0"
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       FEE_RECIPIENT_ADDRESS: ""
       CHECKPOINT_SYNC_URL: ""
       EXTRA_OPTS: ""
-      JAVA_OPTS: "-Xmx5g"
+      JAVA_OPTS: "-Xmx6g"
     volumes:
       - "teku-gnosis-data:/opt/teku/data"
     ports:
@@ -37,7 +37,7 @@ services:
       FEE_RECIPIENT_ADDRESS: ""
       EXIT_VALIDATOR: ""
       KEYSTORES_VOLUNTARY_EXIT: ""
-      JAVA_OPTS: "-Xmx5g"
+      JAVA_OPTS: "-Xmx6g"
     restart: unless-stopped
     image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.0"
     security_opt:

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -13,6 +13,5 @@ COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 RUN apt-get update && apt-get install ca-certificates --yes
 
-ENV JAVA_OPTS="-Xmx5g"
 
 ENTRYPOINT [ "entrypoint.sh" ]


### PR DESCRIPTION
Users should have the option to change Teku's Java Virtual Machine (JVM) memory usage by setting a maximum heap size using the JAVA_OPTS environment variable.

This PR changes the environment variable from Dockerfile to docker-compose.yml so that it appears in the dnp package's configuration.

Context: https://docs.teku.consensys.net/get-started/manage-memory