### PR TITLE
Fix: erigon el http engine setup

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -8,7 +8,7 @@ case $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS in
   HTTP_ENGINE="http://nethermind-xdai.dappnode:8551"
   ;;
 "gnosis-erigon.dnp.dappnode.eth")
-    HTTP_ENGINE="http://gnosis-erigon.dappnode:8551"
+  HTTP_ENGINE="http://gnosis-erigon.dappnode:8551"
   ;;
 *)
   echo "Unknown value for _DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS: $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "19005:19005/tcp"
       - "19005:19005/udp"
     restart: unless-stopped
-    image: "beacon-chain.teku-gnosis.dnp.dappnode.eth:0.1.0"
+    image: "beacon-chain.teku-gnosis.dnp.dappnode.eth:0.1.11"
     security_opt:
       - "seccomp:unconfined"
   validator:
@@ -39,7 +39,7 @@ services:
       KEYSTORES_VOLUNTARY_EXIT: ""
       JAVA_OPTS: "-Xmx6g"
     restart: unless-stopped
-    image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.0"
+    image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.11"
     security_opt:
       - "seccomp:unconfined"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,14 @@ services:
       EXTRA_OPTS: ""
       JAVA_OPTS: "-Xmx6g"
     volumes:
-      - "teku-gnosis-data:/opt/teku/data"
+      - teku-gnosis-data:/opt/teku/data
     ports:
-      - "19005:19005/tcp"
-      - "19005:19005/udp"
+      - 19005:19005/tcp
+      - 19005:19005/udp
     restart: unless-stopped
-    image: "beacon-chain.teku-gnosis.dnp.dappnode.eth:0.1.11"
+    image: beacon-chain.teku-gnosis.dnp.dappnode.eth:0.1.11
     security_opt:
-      - "seccomp:unconfined"
+      - seccomp:unconfined
   validator:
     build:
       context: ./validator
@@ -31,7 +31,7 @@ services:
         UPSTREAM_VERSION: 24.2.0
     environment:
       LOG_TYPE: INFO
-      BEACON_NODE_ADDR: "http://beacon-chain.teku-gnosis.dappnode:3500"
+      BEACON_NODE_ADDR: http://beacon-chain.teku-gnosis.dappnode:3500
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
@@ -39,8 +39,8 @@ services:
       KEYSTORES_VOLUNTARY_EXIT: ""
       JAVA_OPTS: "-Xmx6g"
     restart: unless-stopped
-    image: "validator.teku-gnosis.dnp.dappnode.eth:0.1.11"
+    image: validator.teku-gnosis.dnp.dappnode.eth:0.1.11
     security_opt:
-      - "seccomp:unconfined"
+      - seccomp:unconfined
 volumes:
   teku-gnosis-data: {}

--- a/releases.json
+++ b/releases.json
@@ -4,5 +4,11 @@
     "uploadedTo": {
       "http://172.33.1.5:5001": "Thu, 03 Feb 2022 13:09:30 GMT"
     }
+  },
+  "0.1.11": {
+    "hash": "/ipfs/QmZWkSQu9QGo4UdVxbSqqXA3Wf13K7PrQKo6FrUWQR9X6u",
+    "uploadedTo": {
+      "dappnode": "Thu, 11 Apr 2024 17:24:16 GMT"
+    }
   }
 }


### PR DESCRIPTION
This PR address issue with erigon `HTTP_ENGINE` setup in `entrypoint.sh`. 
Previous version was causing error on startup:

```log
Unknown value for _DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS: gnosis-erigon.dnp.dappnode.eth
Teku failed to start: Endpoint "gnosis-erigon.dnp.dappnode.eth" scheme is not supported.
Use http://, https://, ws://, wss:// or file: for IPC file path
```
This PR fix indentation and formatting eleminating error above.