### PR TITLE
Deprecation of initiali state

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Concatenate EXTRA_OPTS string & remove trailing slash if necessary
-[[ -n $CHECKPOINT_SYNC_URL ]] && EXTRA_OPTS="--initial-state=$(echo $CHECKPOINT_SYNC_URL | sed 's:/*$::')/eth/v2/debug/beacon/states/finalized ${EXTRA_OPTS}"
+[[ -n $CHECKPOINT_SYNC_URL ]] && EXTRA_OPTS="--checkpoint-sync-url=$CHECKPOINT_SYNC_URL ${EXTRA_OPTS}"
 
 case $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS in
 "nethermind-xdai.dnp.dappnode.eth")


### PR DESCRIPTION
Deprecation of initial state in teku release https://github.com/Consensys/teku/releases/tag/25.4.1

> It is no longer possible to set both --checkpoint-sync-url and --initial-state. If your node fails to start after upgrade, ensure that only one of these is set.